### PR TITLE
feat(posts): implement delete own post functionality with full test coverage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { errorHandler } from './utils/errors/error-handler.middleware';
 import cors from "cors";
+import postRoutes from './features/posts/routes/post.routes'; // Adjust the path if your routes file is elsewhere
 
 export const app = express();
 const PORT = 3000;
@@ -10,7 +11,7 @@ app.get('/', (req, res) => {
 });
 app.use(express.json());
 app.use(cors());
-
+app.use('/api', postRoutes);
 // Error handling middleware should be last
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
     errorHandler(err, req, res, next);

--- a/src/features/posts/controllers/post.controller.ts
+++ b/src/features/posts/controllers/post.controller.ts
@@ -1,0 +1,29 @@
+import { Response, NextFunction } from 'express';
+import { deleteOwnPostService } from '../services/post.service';
+import { AuthenticatedRequest } from '../../middleware/authenticate.middleware';
+
+export const deleteOwnPostController = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const userId = req.user.uuid;
+    const { postId } = req.body; 
+
+    if (!postId) {
+      return res.status(400).json({ status: 'error', message: 'Post ID is required.' });
+    }
+
+    const result = await deleteOwnPostService(userId, postId);
+
+    return res.status(200).json({
+      status: 'success',
+      message: 'Post successfully deleted.',
+      data: result,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+

--- a/src/features/posts/repositories/post.repository.ts
+++ b/src/features/posts/repositories/post.repository.ts
@@ -1,0 +1,12 @@
+import client from '../../../config/database';
+
+// Find a post by ID
+export const findPostById = async (postId: string) => {
+    const res = await client.query('SELECT * FROM posts WHERE id = $1', [postId]);
+    return res.rows.length > 0 ? res.rows[0] : null;
+};
+
+// Soft delete the post (set is_active to false)
+export const deleteOwnPostRepository = async (postId: string) => {
+    await client.query('UPDATE posts SET is_active = false WHERE id = $1', [postId]);
+};

--- a/src/features/posts/repositories/reports.repository.ts
+++ b/src/features/posts/repositories/reports.repository.ts
@@ -1,0 +1,31 @@
+// src/repositories/reports.repository.ts
+import client from '../../../config/database';
+
+/**
+ * Fetch sorted reported posts from the database
+ * @param orderBy - Field to sort by (created_at, report_count, username)
+ * @param orderDirection - Sort direction (asc or desc)
+ * @param page - Page number for pagination
+ * @param limit - Number of results per page
+ * @returns Array of reported posts
+ */
+export const getSortedReports = async (
+    orderBy: string,
+    orderDirection: string,
+    page: number,
+    limit: number
+) => {
+    const offset = (page - 1) * limit;
+
+    // SQL Query with sorting and pagination
+    const query = `
+        SELECT * 
+        FROM public.reports 
+        WHERE content_type = 'post' 
+        ORDER BY ${orderBy} ${orderDirection} 
+        LIMIT $1 OFFSET $2;
+    `;
+
+    const res = await client.query(query, [limit, offset]);
+    return res.rows;
+};

--- a/src/features/posts/routes/post.routes.ts
+++ b/src/features/posts/routes/post.routes.ts
@@ -1,0 +1,10 @@
+import { Router ,RequestHandler} from 'express';
+import { authenticateJWT } from '../../middleware/authenticate.middleware';
+import { deleteOwnPostController } from '../controllers/post.controller';
+
+const router = Router();
+
+// Delete own post route (protected by JWT)
+router.delete('/user/posts/delete', authenticateJWT, deleteOwnPostController as RequestHandler);
+
+export default router;

--- a/src/features/posts/services/post.service.ts
+++ b/src/features/posts/services/post.service.ts
@@ -1,0 +1,23 @@
+import { deleteOwnPostRepository, findPostById } from "../repositories/post.repository";
+
+export const deleteOwnPostService = async (userId: string, postId: string) => {
+    // Check if the post exists and is owned by the user
+    const post = await findPostById(postId);
+
+    if (!post) {
+        throw { status: 404, message: 'Post not found.' };
+    }
+
+    if (post.user_id !== userId) {
+        throw { status: 403, message: 'You are not authorized to delete this post.' };
+    }
+
+    if (!post.is_active) {
+        throw { status: 400, message: 'This post is already deleted.' };
+    }
+
+    // Soft delete the post
+    await deleteOwnPostRepository(postId);
+
+    return { postId, deleted: true };
+};

--- a/src/utils/posts/returnReportsValidation.ts
+++ b/src/utils/posts/returnReportsValidation.ts
@@ -1,0 +1,20 @@
+// src/utils/validationUtils.ts
+
+/**
+ * Validates sorting parameters for reported posts
+ * @param orderBy - Field to sort by (created_at, report_count, username)
+ * @param orderDirection - Sort direction (asc or desc)
+ * @throws Error if parameters are invalid
+ */
+export function validateSortingParams(orderBy: string, orderDirection: string) {
+    const validFields = ['created_at', 'report_count', 'username'];
+    const validDirections = ['asc', 'desc'];
+
+    if (!validFields.includes(orderBy)) {
+        throw new Error(`Invalid orderBy field. Allowed values: ${validFields.join(', ')}`);
+    }
+
+    if (!validDirections.includes(orderDirection)) {
+        throw new Error(`Invalid orderDirection. Allowed values: ${validDirections.join(', ')}`);
+    }
+}

--- a/test-api/controller/delete.post.controller.test.ts
+++ b/test-api/controller/delete.post.controller.test.ts
@@ -1,0 +1,55 @@
+import { deleteOwnPostController } from "../../src/features/posts/controllers/post.controller";
+import { deleteOwnPostService } from "../../src/features/posts/services/post.service";
+import { Request, Response, NextFunction } from "express";
+
+jest.mock("../../src/features/posts/services/post.service");
+
+describe("deleteOwnPostController", () => {
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+    let mockNext: NextFunction = jest.fn();
+
+    beforeEach(() => {
+        mockReq = { body: { postId: "post-123" } } as Partial<Request> & { user: { uuid: string } };
+        (mockReq as any).user = { uuid: "user-123" };
+        mockRes = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should delete the post and return 200", async () => {
+        (deleteOwnPostService as jest.Mock).mockResolvedValue({ postId: "post-123", deleted: true });
+
+        await deleteOwnPostController(mockReq as any, mockRes as any, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(200);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            status: "success",
+            message: "Post successfully deleted.",
+            data: { postId: "post-123", deleted: true },
+        });
+    });
+
+    it("should return 400 if postId is missing", async () => {
+        mockReq.body = {};
+
+        await deleteOwnPostController(mockReq as any, mockRes as any, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            status: "error",
+            message: "Post ID is required."
+        });
+    });
+
+    it("should forward errors to next middleware", async () => {
+        const error = { status: 404, message: "Post not found." };
+        (deleteOwnPostService as jest.Mock).mockRejectedValue(error);
+
+        await deleteOwnPostController(mockReq as any, mockRes as any, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(error);
+    });
+});

--- a/test-api/routes/delete.post.routes.test.ts
+++ b/test-api/routes/delete.post.routes.test.ts
@@ -1,0 +1,50 @@
+import request from "supertest";
+import express from "express";
+import { deleteOwnPostController } from "../../src/features/posts/controllers/post.controller";
+import postRoutes from "../../src/features/posts/routes/post.routes";
+import { authenticateJWT } from "../../src/features/middleware/authenticate.middleware";
+
+jest.mock("../../src/features/posts/controllers/post.controller");
+jest.mock("../../src/features/middleware/authenticate.middleware");
+
+const app = express();
+app.use(express.json());
+app.use("/api", postRoutes);
+
+describe("POST /api/user/posts/delete", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should call the controller for an authenticated user", async () => {
+        (authenticateJWT as jest.Mock).mockImplementation((req, res, next) => {
+            req.user = { uuid: "user-123" };
+            next();
+        });
+
+        (deleteOwnPostController as jest.Mock).mockImplementation((req, res) => {
+            res.status(200).json({ status: "success", message: "Post successfully deleted." });
+        });
+
+        const response = await request(app)
+            .delete("/api/user/posts/delete")
+            .send({ postId: "post-123" });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ status: "success", message: "Post successfully deleted." });
+        expect(deleteOwnPostController).toHaveBeenCalled();
+    });
+
+    it("should block unauthenticated users", async () => {
+        (authenticateJWT as jest.Mock).mockImplementation((req, res) => {
+            res.status(401).json({ status: "error", message: "Unauthorized" });
+        });
+
+        const response = await request(app)
+            .delete("/api/user/posts/delete")
+            .send({ postId: "post-123" });
+
+        expect(response.status).toBe(401);
+        expect(response.body).toEqual({ status: "error", message: "Unauthorized" });
+    });
+});

--- a/test-api/services/delete.post.service.test.ts
+++ b/test-api/services/delete.post.service.test.ts
@@ -1,0 +1,62 @@
+import { deleteOwnPostService } from "../../src/features/posts/services/post.service";
+import { findPostById, deleteOwnPostRepository } from "../../src/features/posts/repositories/post.repository";
+
+jest.mock("../../src/features/posts/repositories/post.repository");
+
+describe("deleteOwnPostService", () => {
+    const userId = "user-123";
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should delete the post successfully if it belongs to the user", async () => {
+        (findPostById as jest.Mock).mockResolvedValue({
+            id: "post-123",
+            user_id: userId,
+            is_active: true,
+        });
+
+        await expect(deleteOwnPostService(userId, "post-123")).resolves.toEqual({
+            postId: "post-123",
+            deleted: true,
+        });
+
+        expect(deleteOwnPostRepository).toHaveBeenCalledWith("post-123");
+    });
+
+    it("should throw 404 if the post does not exist", async () => {
+        (findPostById as jest.Mock).mockResolvedValue(null);
+
+        await expect(deleteOwnPostService(userId, "post-123")).rejects.toEqual({
+            status: 404,
+            message: "Post not found."
+        });
+    });
+
+    it("should throw 403 if the post does not belong to the user", async () => {
+        (findPostById as jest.Mock).mockResolvedValue({
+            id: "post-123",
+            user_id: "another-user",
+            is_active: true,
+        });
+
+        await expect(deleteOwnPostService(userId, "post-123")).rejects.toEqual({
+            status: 403,
+            message: "You are not authorized to delete this post."
+        });
+    });
+
+    it("should throw 400 if the post is already deleted", async () => {
+        (findPostById as jest.Mock).mockResolvedValue({
+            id: "post-123",
+            user_id: userId,
+            is_active: false,
+        });
+
+        await expect(deleteOwnPostService(userId, "post-123")).rejects.toEqual({
+            status: 400,
+            message: "This post is already deleted."
+        });
+    });
+});

--- a/test-db/testdb.ts
+++ b/test-db/testdb.ts
@@ -1,0 +1,15 @@
+import client from "../src/config/database";
+
+const testConnection = async () => {
+  try {
+    const result = await client.query("SELECT NOW()");
+    console.log("Conexión exitosa. Hora del servidor:");
+    console.log(result.rows[0]);
+  } catch (error) {
+    console.error("Error en la conexión o consulta:", error);
+  } finally {
+    await client.end();
+  }
+};
+
+testConnection();


### PR DESCRIPTION
- Implemented delete own post service with user validation.
- Created delete own post controller with error handling for missing postId, unauthorized user, and already deleted post.
- Set up route for delete own post with JWT authentication middleware.
- Added tests for service, controller, and route.
- Used Jest to mock services and middleware, ensuring isolated tests without database interactions.