### PR TITLE
fix(Dockerfile): update Node.js version from 18 to 22 for builder and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Setting the working directory in the container, to where things will be copied to and run from
 WORKDIR /app
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Lightweight production image
-FROM node:18-alpine AS runner
+FROM node:22-alpine AS runner
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use a newer version of the Node.js runtime, improving compatibility and performance.

Updates to Node.js version:

* Updated the base image for the `builder` stage from `node:18-alpine` to `node:22-alpine` to use the latest Node.js LTS version. (`Dockerfile`, [DockerfileL1-R1](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1))
* Updated the base image for the `runner` stage from `node:18-alpine` to `node:22-alpine` to align with the updated builder stage and maintain consistency. (`Dockerfile`, [DockerfileL16-R16](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L16-R16))… runner stages