### PR TITLE
fix: ensure only active posts are retrieved in getVisiblePostsByUserI…

### DIFF
--- a/src/features/posts/repositories/getPosts.repository.ts
+++ b/src/features/posts/repositories/getPosts.repository.ts
@@ -14,7 +14,7 @@ export const getVisiblePostsByUserIdPaginated = async (user_id: string, offset: 
   // Fetching user UUID by email
   const postQuery = `
     SELECT id, content, file_url, media_type, created_at FROM posts 
-    WHERE user_id = $1 AND status = 1 
+    WHERE user_id = $1 AND status = 1 AND is_active = true
     ORDER BY created_at DESC 
     LIMIT $2 OFFSET $3
   `;


### PR DESCRIPTION
This pull request includes a small but meaningful change to the query in the `getVisiblePostsByUserIdPaginated` function. The change ensures that only posts marked as active (`is_active = true`) are fetched, in addition to the existing conditions.

* [`src/features/posts/repositories/getPosts.repository.ts`](diffhunk://#diff-29dda281b46f61300f69f604d2b9b4297a14c2ca798dccec25634e0abd91de3cL17-R17): Modified the SQL query to include a filter for `is_active = true`, ensuring only active posts are retrieved.