### PR TITLE
Feat/posts by user

### DIFF
--- a/docs/Get Posts By User-20250606181000.md
+++ b/docs/Get Posts By User-20250606181000.md
@@ -1,0 +1,116 @@
+# Get Posts By User
+
+`GET /api/posts/user/:uuid`
+
+#### Path Parameters
+
+```plain
+uuid    // required, the user's UUID whose posts you want to retrieve
+```
+
+#### Query parameters
+
+```plain
+{
+  "page": 1, // optional, default: 1, must be an integer >= 1
+  "limit": 10, // optional, default: 10, must be an integer between 1 and 20. Represents the maximum number of posts to return.
+  "time": "2025-06-02-T14:05:47.843Z",  //To be defined 
+}
+```
+
+*   The first query, you must send the current time,
+*   Consecutive queries, you must send the time of the last post received if any.
+
+  
+
+#### Headers
+
+```plain
+Authorization: Bearer <jwt-token>    // required, must be a valid JWT token
+```
+```
+
+### Example Request (JavaScript)
+
+```javascript
+// Example using fetch API
+const fetchPostsByUser = async (userUuid) => {
+  try {
+    // URL with path parameter and query parameters
+    const url = new URL(`https://api.example.com/api/posts/user/${userUuid}`);
+    url.searchParams.append('page', '1');
+    url.searchParams.append('limit', '10');
+    url.searchParams.append('time', new Date().toISOString());
+    
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' // Your JWT token here
+      }
+    });
+    
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+    
+    const data = await response.json();
+    console.log('Posts fetched successfully:', data);
+    return data;
+  } catch (error) {
+    console.error('Error fetching posts:', error);
+    throw error;
+  }
+};
+```
+
+### Proposed response
+
+```cs
+{
+    "message": "Posts fetched successfully",
+    "data": [
+        {
+            "id": "819aafdd-4219-4dbe-936b-70b1586f9b63",
+            "user_id": "aad06c03-08b8-4030-b006-c988347d9610",
+            "content": "Test post for testing modules :)",
+            "file_url": null,
+            "media_type": null,
+            "created_at": "2025-06-04T00:57:09.943Z"
+        },
+        {
+            "id": "8983e2e8-2adc-4c9d-981a-2752a38b0b6f",
+            "user_id": "aad06c03-08b8-4030-b006-c988347d9610",
+            "content": "The city lights at night are magical.",
+            "file_url": "https://utfs.io/f/Ri7z8Bp5NkcuSsRFTF28bkwdnrlPpeatI3YT79JCshAQ4vDS",
+            "media_type": 0,
+            "created_at": "2025-05-24T21:40:08.823Z"
+        },
+        {
+            "id": "899ad40f-e894-4148-9626-33c89704f472",
+            "user_id": "aad06c03-08b8-4030-b006-c988347d9610",
+            "content": "'Weekend vibes with my favorite people. ❤️",
+            "file_url": "https://utfs.io/f/Ri7z8Bp5NkcuG9crTMObsZV7pcGS2xiledFznMgvA0UuHEhR",
+            "media_type": 0,
+            "created_at": "2025-05-24T21:39:47.120Z"
+        },
+        ... other 7 posts ...
+    ],
+    "metadata": {
+        "totalItems": 39,
+        "totalPages": 4,
+        "currentPage": 1
+    }
+}
+
+
+```
+
+### Expected Status Codes
+
+| Code | Error Type | Description |
+| ---| ---| --- |
+| 200 | Success | Posts fetched successfully. |
+| 400 | Bad Request | One or more query parameters don't meet the established validations. |
+| 401 | Unauthorized | Invalid or missing JWT token. |
+| 404 | Not Found | User with the specified UUID was not found. |
+| 500 | Internal Server Error | Unexpected server error (e.g., DB connection error, etc). |

--- a/docs/Get Posts By User-20250606181000.md
+++ b/docs/Get Posts By User-20250606181000.md
@@ -12,7 +12,6 @@ uuid    // required, the user's UUID whose posts you want to retrieve
 
 ```plain
 {
-  "page": 1, // optional, default: 1, must be an integer >= 1
   "limit": 10, // optional, default: 10, must be an integer between 1 and 20. Represents the maximum number of posts to return.
   "time": "2025-06-02-T14:05:47.843Z",  //To be defined 
 }
@@ -96,9 +95,8 @@ const fetchPostsByUser = async (userUuid) => {
         ... other 7 posts ...
     ],
     "metadata": {
-        "totalItems": 39,
-        "totalPages": 4,
-        "currentPage": 1
+        "remainingItems": 39,
+        "remainingPages": 4
     }
 }
 

--- a/src/features/posts/controllers/getPosts.controller.ts
+++ b/src/features/posts/controllers/getPosts.controller.ts
@@ -1,9 +1,14 @@
 import { NextFunction, Request, Response, RequestHandler } from 'express';
-import { getUserPosts } from '../services/getPosts.service';
+import { getUserPosts, getPostsByUserId } from '../services/getPosts.service';
 import * as yup from 'yup';
 import { AuthenticatedRequest } from '../../middleware/authenticate.middleware';
 import { BadRequestError, UnauthorizedError } from '../../../utils/errors/api-error';
-import { getUserPostsSchema, GetUserPostsDTO } from '../dto/getUserPosts.dto';
+import { 
+  getUserPostsSchema, 
+  GetUserPostsDTO, 
+  getOtherUserPostsSchema, 
+  GetOtherUserPostsDTO 
+} from '../dto/getUserPosts.dto';
 
 /**
  * Controller to handle fetching paginated posts for the authenticated user.
@@ -41,3 +46,53 @@ export const getUserPostsController = async (
     }
   }
 };
+
+/**
+ * Controller to handle fetching paginated posts for a specific user by UUID.
+ *
+ * @param req - Express request object, extended with authenticated user info.
+ * @param res - Express response object.
+ * @param next - Express next middleware function for error handling.
+ * @returns Responds with paginated posts and metadata, or passes errors to the error handler.
+ * @throws BadRequestError if validation fails, UnauthorizedError if user is not authorized, or other errors from the service layer.
+ */
+export const getPostsByUserIdController = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    // Validate and cast both params and query parameters
+    const validatedData = await getOtherUserPostsSchema.validate(
+      {
+        params: req.params,
+        query: req.query
+      },
+      {
+        abortEarly: false,
+        stripUnknown: true,
+      }
+    ) as GetOtherUserPostsDTO;
+
+    // Check if the user is authorized
+    if (req.user.role !== 'user') {
+      throw new UnauthorizedError('User not authenticated');
+    }
+
+    // Extract validated data
+    const { uuid } = validatedData.params;
+    const { limit, time } = validatedData.query;
+
+    // Call service function (you'll need to create or modify the appropriate service)
+    const posts = await getPostsByUserId(uuid, limit, time);
+    
+    res.status(200).json(posts);
+  } catch (error) {
+    if (error instanceof yup.ValidationError) {
+      next(new BadRequestError('Validation error', error.errors));
+    } else {
+      next(error);
+    }
+  }
+};
+

--- a/src/features/posts/dto/getUserPosts.dto.ts
+++ b/src/features/posts/dto/getUserPosts.dto.ts
@@ -15,4 +15,30 @@ export const getUserPostsSchema = yup.object({
     .default(10),
 });
 
+export const getOtherUserPostsSchema = yup.object({
+  params: yup.object({
+    uuid: yup.string()
+      .uuid('The user ID must be a valid UUID')
+      .required('User UUID is required'),
+  }),
+  query: yup.object({
+    limit: yup
+      .number()
+      .integer('The limit must be an integer')
+      .min(1, 'The limit must be at least 1')
+      .max(20, 'The limit must not exceed 20')
+      .default(10),
+    
+    time: yup
+      .string()
+      .test(
+        'is-date',
+        'Time must be a valid ISO date string',
+        (value) => !value || !isNaN(Date.parse(value))
+      )
+      .required('Time is required')
+  }),
+});
+
 export type GetUserPostsDTO = yup.InferType<typeof getUserPostsSchema>;
+export type GetOtherUserPostsDTO = yup.InferType<typeof getOtherUserPostsSchema>;

--- a/src/features/posts/interfaces/posts.entities.interface.ts
+++ b/src/features/posts/interfaces/posts.entities.interface.ts
@@ -21,4 +21,13 @@ export interface PaginatedResponse<T> {
   };
 }
 
+export interface PaginatedTimeResponse<T> {
+  message: string;
+  data: T[];
+  metadata: {
+    remainingItems: number;
+    remainingPages: number;
+  };
+}
+
 export interface Post extends BasePost {}

--- a/src/features/posts/repositories/getPosts.repository.ts
+++ b/src/features/posts/repositories/getPosts.repository.ts
@@ -25,6 +25,29 @@ export const getVisiblePostsByUserIdPaginated = async (user_id: string, offset: 
 };
 
 /**
+ * Retrieves paginated visible posts for a user by their user ID, filtered by creation time.
+ * Only returns posts created before the provided timestamp.
+ *
+ * @param user_id - The UUID of the user whose posts are being fetched.
+ * @param timestamp - The ISO timestamp to filter posts (returns posts created before this time).
+ * @param limit - The maximum number of rows to return (for pagination).
+ * @returns An array of post objects if found, otherwise an empty array.
+ * @throws Any error thrown by the database client.
+ */
+export const getVisiblePostsByUserIdAndTime = async (user_id: string, timestamp: string, limit: number) => {
+  const postQuery = `
+    SELECT id, user_id, content, file_url, media_type, created_at FROM posts 
+    WHERE user_id = $1 AND status = 1 AND is_active = true AND created_at < $2
+    ORDER BY created_at DESC 
+    LIMIT $3
+  `;
+
+  const postResult: QueryResult = await client.query(postQuery, [user_id, timestamp, limit]);
+
+  return postResult.rows.length > 0 ? postResult.rows : [];
+};
+
+/**
  * Retrieves the total number of visible posts for a user by their user ID.
  *
  * @param user_id - The UUID of the user whose post count is being fetched.
@@ -34,6 +57,21 @@ export const getVisiblePostsByUserIdPaginated = async (user_id: string, offset: 
 export const getTotalVisiblePostsByUserId = async (user_id: string) => {
   const countQuery = 'SELECT COUNT(*) FROM posts WHERE user_id = $1 AND status = $2';
   const countResult: QueryResult = await client.query(countQuery, [user_id, 1]);
+
+  return parseInt(countResult.rows[0].count, 10);
+};
+
+/**
+ * Retrieves the total number of visible posts for a user by their user ID, created before a specific time.
+ *
+ * @param user_id - The UUID of the user whose post count is being fetched.
+ * @param timestamp - The ISO timestamp to filter posts (counts posts created before this time).
+ * @returns The total count of visible posts for the user as a number.
+ * @throws Any error thrown by the database client.
+ */
+export const getTotalVisiblePostsByUserIdAndTime = async (user_id: string, timestamp: string) => {
+  const countQuery = 'SELECT COUNT(*) FROM posts WHERE user_id = $1 AND status = $2 AND is_active = true AND created_at < $3';
+  const countResult: QueryResult = await client.query(countQuery, [user_id, 1, timestamp]);
 
   return parseInt(countResult.rows[0].count, 10);
 };

--- a/src/features/posts/routes/post.routes.ts
+++ b/src/features/posts/routes/post.routes.ts
@@ -1,21 +1,27 @@
 import { Router ,RequestHandler} from 'express';
 import { authenticateJWT } from '../../middleware/authenticate.middleware';
-import { getUserPostsController } from '../controllers/getPosts.controller';
+import { getUserPostsController, getPostsByUserIdController } from '../controllers/getPosts.controller';
 import { deleteOwnPostController } from '../controllers/post.controller';
 import { getReportedPostsController } from "../controllers/reportedPosts.controller";
 import { createPostController } from '../controllers/postCrud.controller';
 
 const router = Router();
 
+// GET
 // Get user posts route (protected by JWT)
 router.get('/user/posts/mine', authenticateJWT, getUserPostsController as RequestHandler);
 
-// Delete own post route (protected by JWT)
-router.delete('/user/posts/delete/:postId', authenticateJWT, deleteOwnPostController as unknown as RequestHandler);
+// Get posts for a specific user by UUID route (protected by JWT)
+router.get('/posts/user/:uuid', authenticateJWT, getPostsByUserIdController as RequestHandler);
 
 // Get all reported posts route (protected by JWT)
 router.get('/posts/reported', authenticateJWT, getReportedPostsController as RequestHandler);
 
+// DELETE
+// Delete own post route (protected by JWT)
+router.delete('/user/posts/delete/:postId', authenticateJWT, deleteOwnPostController as unknown as RequestHandler);
+
+// POST
 // Create a new post (protected by JWT)
 router.post('/posts/newPost', authenticateJWT, createPostController as RequestHandler);
 

--- a/test-api/services/userPosts.service.test.ts
+++ b/test-api/services/userPosts.service.test.ts
@@ -1,6 +1,6 @@
-import { getUserPosts } from '../../src/features/posts/services/getPosts.service';
+import { getUserPosts, getPostsByUserId } from '../../src/features/posts/services/getPosts.service';
 import * as userPostsRepository from '../../src/features/posts/repositories/getPosts.repository';
-import { InternalServerError } from '../../src/utils/errors/api-error';
+import { InternalServerError, NotFoundError } from '../../src/utils/errors/api-error';
 
 jest.mock('../../src/features/posts/repositories/getPosts.repository');
 
@@ -62,6 +62,93 @@ describe('UserPosts Service', () => {
       (userPostsRepository.getTotalVisiblePostsByUserId as jest.Mock).mockRejectedValueOnce(new Error('Database error'));
 
       await expect(getUserPosts('user-uuid', 1, 10)).rejects.toThrow(InternalServerError);
+    });
+  });
+
+  describe('getPostsByUserId', () => {
+    it('should return posts and metadata when posts are found before the given timestamp', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          user_id: 'user-uuid',
+          content: 'Test post',
+          file_url: 'https://example.com/file.jpg',
+          media_type: 1,
+          created_at: new Date('2025-05-01T12:00:00Z'),
+        },
+      ];
+      
+      const timestamp = '2025-05-05T12:00:00.000Z';
+      const limit = 10;
+
+      (userPostsRepository.getTotalVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(3);
+      (userPostsRepository.getVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(mockPosts);
+
+      const result = await getPostsByUserId('user-uuid', limit, timestamp);
+
+      expect(userPostsRepository.getTotalVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp);
+      expect(userPostsRepository.getVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp, limit);
+      expect(result).toEqual({
+        message: 'Posts fetched successfully',
+        data: mockPosts,
+        metadata: {
+          remainingItems: 2,  // 3 total - 1 returned = 2 remaining
+          remainingPages: 1,  // Math.ceil(2/10) = 1
+        },
+      });
+    });
+
+    it('should return empty posts and metadata when no posts are found before the given timestamp', async () => {
+      const timestamp = '2025-05-05T12:00:00.000Z';
+      const limit = 10;
+
+      (userPostsRepository.getTotalVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(0);
+      (userPostsRepository.getVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce([]);
+
+      const result = await getPostsByUserId('user-uuid', limit, timestamp);
+
+      expect(userPostsRepository.getTotalVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp);
+      expect(userPostsRepository.getVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp, limit);
+      expect(result).toEqual({
+        message: 'Posts fetched successfully',
+        data: [],
+        metadata: {
+          remainingItems: 0,
+          remainingPages: 0,
+        },
+      });
+    });
+
+    it('should throw NotFoundError when getTotalVisiblePostsByUserIdAndTime fails', async () => {
+      const timestamp = '2025-05-05T12:00:00.000Z';
+      const limit = 10;
+
+      (userPostsRepository.getTotalVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await expect(getPostsByUserId('user-uuid', limit, timestamp)).rejects.toThrow(NotFoundError);
+      expect(userPostsRepository.getTotalVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp);
+    });
+
+    it('should throw InternalServerError when getVisiblePostsByUserIdAndTime fails', async () => {
+      const timestamp = '2025-05-05T12:00:00.000Z';
+      const limit = 10;
+
+      (userPostsRepository.getTotalVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(5);
+      (userPostsRepository.getVisiblePostsByUserIdAndTime as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await expect(getPostsByUserId('user-uuid', limit, timestamp)).rejects.toThrow(InternalServerError);
+      expect(userPostsRepository.getTotalVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp);
+      expect(userPostsRepository.getVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp, limit);
+    });
+
+    it('should throw InternalServerError when any other error occurs', async () => {
+      const timestamp = '2025-05-05T12:00:00.000Z';
+      const limit = 10;
+
+      (userPostsRepository.getTotalVisiblePostsByUserIdAndTime as jest.Mock).mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(getPostsByUserId('user-uuid', limit, timestamp)).rejects.toThrow(InternalServerError);
+      expect(userPostsRepository.getTotalVisiblePostsByUserIdAndTime).toHaveBeenCalledWith('user-uuid', timestamp);
     });
   });
 });


### PR DESCRIPTION
This pull request introduces a new feature to fetch **paginated posts** for a specific user by their **UUID**, filtered by **creation time,** along with corresponding API documentation, controller logic, service layer, repository functions, and tests. 

### Service and Repository Updates:
* Introduced `getPostsByUserId` service to fetch paginated posts filtered by time, including metadata for remaining items and pages. (`src/features/posts/services/getPosts.service.ts`)
* Added repository functions `getVisiblePostsByUserIdAndTime` and `getTotalVisiblePostsByUserIdAndTime` to query posts and their count based on a timestamp filter. (`src/features/posts/repositories/getPosts.repository.ts`) [[1]](diffhunk://#diff-29dda281b46f61300f69f604d2b9b4297a14c2ca798dccec25634e0abd91de3cR27-R49) [[2]](diffhunk://#diff-29dda281b46f61300f69f604d2b9b4297a14c2ca798dccec25634e0abd91de3cR63-R77)

## Important
This is a base implementation for future paginated functionalities, so, another PR will be the integration and refactor with other similar functionalitites.