### PR TITLE
feat: add dummy endpoints for create comments and get feed posts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { errorHandler } from './utils/errors/error-handler.middleware';
 import cors from "cors";
 import postRoutes from './features/posts/routes/post.routes';
 import reportedPostsRoutes from './features/posts/routes/reportedPosts.routes';
+import commentRoutes from './features/posts/routes/comment.routes';
 
 export const app = express();
 const PORT = 3000;
@@ -16,6 +17,7 @@ app.use(cors());
 // Add the user posts routes
 app.use('/api', postRoutes);
 app.use('/api', reportedPostsRoutes);
+app.use('/api', commentRoutes);
 
 // Error handling middleware should be last
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {

--- a/src/features/posts/controllers/commentCrud.controller.ts
+++ b/src/features/posts/controllers/commentCrud.controller.ts
@@ -1,21 +1,70 @@
 import { Response, NextFunction } from 'express';
 import * as yup from 'yup';
 import { AuthenticatedRequest } from '../../middleware/authenticate.middleware';
+
 import {BadRequestError, UnauthorizedError} from '../../../utils/errors/api-error';
 import { createCommentSchema } from '../dto/commentsCrud.dto';
 import { getPostCommentsSchema, GetPostCommentsDTO } from '../dto/commentsCrud.dto';
 import { getPostComments } from '../services/commentCrud.service';
+import multer from 'multer';
 
-export const createCommentDummyController = async (
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB
+  fileFilter: (req, file, cb) => {
+    if (
+      file.mimetype.startsWith('image/') ||
+      file.mimetype === 'image/gif'
+    ) {
+      cb(null, true);
+    } else {
+      cb(null, false);
+      cb(new Error('Solo se permiten archivos de imagen o GIF'));
+    }
+  }
+}).any();
+
+export const createCommentController = async (
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction
 ) => {
   try {
+    await new Promise<void>((resolve, reject) => {
+      upload(req, res, (err) => {
+        if (err instanceof multer.MulterError) {
+          reject(new BadRequestError(`Error creating comment: ${err.message}`));
+        } else if (err) {
+          reject(new BadRequestError(`Error creating comment: ${err.message}`));
+        } else {
+          resolve();
+        }
+      });
+    });
+
     const validatedBody = await createCommentSchema.validate(req.body, {
       abortEarly: false,
       stripUnknown: true,
     });
+
+    const files = req.files as Express.Multer.File[] | undefined;
+    const file = files && files.length > 0 ? files[0] : undefined;
+
+    if ((!validatedBody.content || validatedBody.content.length === 0) && !file) {
+      throw new BadRequestError('At least one of content or file is required.');
+    }
+
+    if ((validatedBody.mediaType === 0 || validatedBody.mediaType === 1) && !file) {
+      throw new BadRequestError('If mediaType is 0 or 1, file is required.');
+    }
+
+    if (file && !(validatedBody.mediaType === 0 || validatedBody.mediaType === 1)) {
+      throw new BadRequestError('If file is present, mediaType must be 0 or 1.');
+    }
+
+    if (req.file && !(validatedBody.mediaType === 0 || validatedBody.mediaType === 1)) {
+      throw new BadRequestError('If file is present, mediaType must be 0 or 1.');
+    }
 
     res.status(201).json({
       message: 'Comentario recibido correctamente',

--- a/src/features/posts/controllers/postCrud.controller.ts
+++ b/src/features/posts/controllers/postCrud.controller.ts
@@ -40,8 +40,6 @@ export const createPostController = async (req: AuthenticatedRequest, res: Respo
     const files = req.files as Express.Multer.File[] | undefined;
     const file = files && files.length > 0 ? files[0] : undefined;
 
-    console.log('Body:', req.body);
-
     const validatedBody = await createPostSchema.validate(req.body, {
       abortEarly: false,
       stripUnknown: true,
@@ -90,6 +88,7 @@ export const getPostsFeedController = async (req: AuthenticatedRequest, res: Res
 
     // // Assuming you have a service to get the posts feed
     // const postsFeed = await getPostsFeed(email, token);
+
     const postsFeed: FeedPost[] = Array.from({ length: 10 }).map((_, i) => ({
       id: (i + 1).toString(),
       user_id: 'user' + (i + 1),
@@ -105,7 +104,6 @@ export const getPostsFeedController = async (req: AuthenticatedRequest, res: Res
       username: `usuario${i + 1}`,
       profile_picture_url: `https://dummyimage.com/100x100/${i % 2 === 0 ? '000/fff' : '111/eee'}`,
     }));
-
 
     res.status(200).json({
       message: 'Posts feed retrieved successfully',

--- a/src/features/posts/dto/commentsCrud.dto.ts
+++ b/src/features/posts/dto/commentsCrud.dto.ts
@@ -8,15 +8,14 @@ export const createCommentSchema = yup.object({
 
   content: yup
     .string()
-    .required('content is required')
-    .min(1, 'Content must be at least 1 character long')
+    .nullable()
     .max(300, 'Content must not exceed 300 characters'),
 
   mediaType: yup
     .number()
     .transform((value, originalValue) => originalValue === "" ? null : value)
-    .nullable(),
-
+    .nullable()
+    .oneOf([0, 1, 2, null], 'mediaType must be 0, 1 or 2'),
   file: yup
     .mixed()
     .nullable(),
@@ -25,33 +24,6 @@ export const createCommentSchema = yup.object({
     .string()
     .nullable(),
 })
-.test(
-  'at-least-content-or-file',
-  'At least one of content or file is required.',
-  (value) => {
-    return (value.content && value.content.length > 0) || !!value.file;
-  }
-)
-.test(
-  'file-required-if-mediatype',
-  'If mediaType is 0 or 1, file is required.',
-  (value) => {
-    if (value.mediaType === 0 || value.mediaType === 1) {
-      return !!value.file;
-    }
-    return true;
-  }
-)
-.test(
-  'mediatype-required-if-file',
-  'If file is present, mediaType must be 0 or 1.',
-  (value) => {
-    if (value.file) {
-      return value.mediaType === 0 || value.mediaType === 1;
-    }
-    return true;
-  }
-)
 .test(
   'gifurl-not-allowed-if-mediatype-not-2',
   'gifUrl is only allowed if mediaType is 2.',
@@ -90,4 +62,4 @@ export const getPostCommentsSchema = yup.object({
 });
 
 export type GetPostCommentsDTO = yup.InferType<typeof getPostCommentsSchema>;
-
+export type CreateCommentDTO = yup.InferType<typeof createCommentSchema>;

--- a/src/features/posts/dto/postCrud.dto.ts
+++ b/src/features/posts/dto/postCrud.dto.ts
@@ -32,18 +32,10 @@ export const createPostSchema = yup.object({
 );
 
 export const getFeedPostsSchema = yup.object({
-  page: yup
-    .number()
-    .integer('The page must be an integer')
-    .min(1, 'The page must be at least 1')
-    .default(1),
-
   limit: yup
     .number()
     .integer('The limit must be an integer')
     .min(1, 'The limit must be at least 1')
-    .max(5, 'The limit must not exceed 5')
-
     .max(10, 'The limit must not exceed 5')
     .default(10),
   date: yup

--- a/src/features/posts/routes/comment.routes.ts
+++ b/src/features/posts/routes/comment.routes.ts
@@ -1,0 +1,12 @@
+import { Router ,RequestHandler} from 'express';
+import { authenticateJWT } from '../../middleware/authenticate.middleware';
+import { createCommentController, getPostCommentsController } from '../controllers/commentCrud.controller';
+
+const router = Router();
+
+// Create a new comment on a post (protected by JWT)
+router.post('/posts/newComment', authenticateJWT, createCommentController as RequestHandler);
+
+router.get('/posts/:postId/comments', authenticateJWT, getPostCommentsController as RequestHandler);
+
+export default router;

--- a/src/features/posts/routes/post.routes.ts
+++ b/src/features/posts/routes/post.routes.ts
@@ -4,7 +4,6 @@ import { getUserPostsController, getPostsByUserIdController } from '../controlle
 import { deleteOwnPostController } from '../controllers/post.controller';
 import { getReportedPostsController } from "../controllers/reportedPosts.controller";
 import { createPostController, getPostsFeedController } from '../controllers/postCrud.controller';
-import {getPostCommentsController} from "../controllers/commentCrud.controller";
 
 const router = Router();
 
@@ -18,20 +17,15 @@ router.get('/posts/user/:uuid', authenticateJWT, getPostsByUserIdController as R
 // Get all reported posts route (protected by JWT)
 router.get('/posts/reported', authenticateJWT, getReportedPostsController as RequestHandler);
 
+// Get posts feed route (protected by JWT)
+router.get('/posts/feed', authenticateJWT, getPostsFeedController as RequestHandler)
+
 // DELETE
 // Delete own post route (protected by JWT)
 router.delete('/user/posts/delete/:postId', authenticateJWT, deleteOwnPostController as unknown as RequestHandler);
 
 // POST
 // Create a new post (protected by JWT)
-router.post('/posts/newPost', authenticateJWT, createPostController as RequestHandler);
-
-// Get posts feed route (protected by JWT)
-router.get('/posts/feed', authenticateJWT, getPostsFeedController as RequestHandler);
-
-// Create a new comment on a post (protected by JWT)
-router.post('/posts/newCommment', authenticateJWT, createPostController as RequestHandler);
-
-router.get('/posts/:postId/comments', authenticateJWT, getPostCommentsController as RequestHandler);
+router.post('/posts/newPost', authenticateJWT, createPostController as RequestHandler);;
 
 export default router;

--- a/test-api/routes/comment.routes.test.ts
+++ b/test-api/routes/comment.routes.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../src/features/posts/controllers/commentCrud.controller');
 
 import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
 import { getPostCommentsController } from '../../src/features/posts/controllers/commentCrud.controller';
-import commentRoutes from '../../src/features/posts/routes/post.routes';
+import commentRoutes from '../../src/features/posts/routes/comment.routes';
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
# Pull Request Description

## Title
Add Dummy Endpoints for Creating Comments and Fetching Posts Feed

## Description
This pull request introduces two dummy endpoints to the `post.routes.ts` file, both protected by JWT authentication. These endpoints are placeholders and do not yet include full functionality.

### 1. Create a New Comment on a Post
- **Route:** `POST /posts/newComment`
- **Middleware:** `authenticateJWT`
- **Controller:** [`createCommentController`](src/features/posts/controllers/commentCrud.controller.ts:line)
- **Functionality:** Placeholder endpoint for adding comments to posts. Full functionality will be implemented in a future pull request.

### 2. Get Posts Feed
- **Route:** `GET /posts/feed`
- **Middleware:** `authenticateJWT`
- **Controller:** [`getPostsFeedController`](src/features/posts/controllers/getPosts.controller.ts:line)
- **Functionality:** Placeholder endpoint for fetching posts feed. This is not personalized and will be expanded in a future pull request.

## Changes Made
- Added the above routes to [`post.routes.ts`](src/features/posts/routes/post.routes.ts:line).
- Integrated JWT authentication middleware for secure access.
- Connected the routes to their respective controllers as placeholders.

## Testing
- Verified that the routes are accessible and protected by JWT authentication.
- No business logic testing was performed as these are dummy endpoints.

## Impact
These additions prepare the application for future functionality by establishing the necessary routes and middleware.