### PR TITLE
Add retrieve is_active equal to false for post by postId

### DIFF
--- a/src/features/posts/repositories/getPosts.repository.ts
+++ b/src/features/posts/repositories/getPosts.repository.ts
@@ -87,6 +87,8 @@ export const getPostByIdWithDetails = async (postId: string) => {
       p.media_type,
       p.created_at,
       p.updated_at,
+      p.status,
+      p.is_active,
       u.username,
       u.email,
       (SELECT COUNT(*) FROM comments c WHERE c.post_id = p.id) AS total_comments,
@@ -94,9 +96,9 @@ export const getPostByIdWithDetails = async (postId: string) => {
       COALESCE((SELECT COUNT(*) FROM reports r WHERE r.reported_content_id = p.id), 0) AS total_reports
     FROM posts p
     JOIN users u ON p.user_id = u.id
-    WHERE p.id = $1 AND p.is_active = true
+    WHERE p.id = $1
   `;
-  
+
   const result = await client.query(query, [postId]);
   return result.rows.length > 0 ? result.rows[0] : null;
 };

--- a/test-api/repositories/getPostById.repository.test.ts
+++ b/test-api/repositories/getPostById.repository.test.ts
@@ -74,10 +74,9 @@ describe('getPostByIdWithDetails repository', () => {
       ['123']
     );
     
-    // Verify the query includes joins with user table and is selecting visible posts only
+    // Verify the query includes joins with user table and all required fields
     const queryCall = mockClient.query.mock.calls[0][0];
     expect(queryCall.toLowerCase()).toContain('join users');
-    expect(queryCall.toLowerCase()).toContain('is_active = true');
     expect(queryCall.toLowerCase()).toContain('total_comments');
     expect(queryCall.toLowerCase()).toContain('active_reports');
     expect(queryCall.toLowerCase()).toContain('total_reports');
@@ -103,7 +102,7 @@ describe('getPostByIdWithDetails repository', () => {
     );
   });
 
-  it('should return null when post exists but is not visible', async () => {
+  it('should return post details even if post is not visible', async () => {
     const mockPost: PostWithUserDetails = {
       id: '123',
       content: 'Test post content',
@@ -121,8 +120,8 @@ describe('getPostByIdWithDetails repository', () => {
     };
 
     const mockQueryResult: QueryResult<PostWithUserDetails> = {
-      rows: [],
-      rowCount: 0,
+      rows: [mockPost],
+      rowCount: 1,
       command: 'SELECT',
       oid: 0,
       fields: []
@@ -132,7 +131,7 @@ describe('getPostByIdWithDetails repository', () => {
 
     const result = await getPostByIdWithDetails('123');
 
-    expect(result).toBeNull();
+    expect(result).toEqual(mockPost);
   });
 
   it('should include user details in the result', async () => {


### PR DESCRIPTION
# Type of change

[x] fix

## Description
This enhances the `getPostByIdWithDetails` repository function by adding post status and activity indicators to the query results, providing crucial information for content moderation and user experience management.

## Changes
- Added `status` field to post detail query results
- Added `is_active` field to track post visibility state
- Modified query to return posts regardless of active status
- Ensured comprehensive metadata for moderation purposes

## Implementation Details
The function now explicitly includes status fields in the query:
```sql
SELECT 
  p.id,
  p.user_id,
  p.content,
  p.file_url,
  p.file_size,
  p.media_type,
  p.created_at,
  p.updated_at,
  p.status,       /* Added status field */
  p.is_active,    /* Added is_active field */
  u.username,
  u.email,
  ...
```