### PR TITLE
Restrict access on suspended accounts | Post Microservices

### DIFF
--- a/src/features/middleware/suspension.middleware.ts
+++ b/src/features/middleware/suspension.middleware.ts
@@ -1,0 +1,24 @@
+import {Response, NextFunction, Request} from 'express';
+import { AuthenticatedRequest } from './authenticate.middleware';
+import { isUserSuspended } from '../users/repositories/userSuspension.repository';
+import { ForbiddenError } from '../../utils/errors/api-error';
+
+
+export const checkUserSuspension = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const userId = req.user.uuid;
+        const suspended = await isUserSuspended(userId);
+
+        if (suspended) {
+            throw new ForbiddenError('User account is suspended');
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/features/posts/routes/comment.routes.ts
+++ b/src/features/posts/routes/comment.routes.ts
@@ -1,12 +1,13 @@
 import { Router ,RequestHandler} from 'express';
 import { authenticateJWT } from '../../middleware/authenticate.middleware';
+import { checkUserSuspension } from '../../middleware/suspension.middleware';
 import { createCommentController, getPostCommentsController } from '../controllers/commentCrud.controller';
 
 const router = Router();
 
 // Create a new comment on a post (protected by JWT)
-router.post('/posts/newComment', authenticateJWT, createCommentController as RequestHandler);
+router.post('/posts/newComment', authenticateJWT, checkUserSuspension, createCommentController as RequestHandler);
 
-router.get('/posts/:postId/comments', authenticateJWT, getPostCommentsController as RequestHandler);
+router.get('/posts/:postId/comments', authenticateJWT, checkUserSuspension, getPostCommentsController as RequestHandler);
 
 export default router;

--- a/src/features/posts/routes/post.routes.ts
+++ b/src/features/posts/routes/post.routes.ts
@@ -3,32 +3,33 @@ import { authenticateJWT } from '../../middleware/authenticate.middleware';
 import { getUserPostsController, getPostsByUserIdController, getPostByIdController } from '../controllers/getPosts.controller';
 import { deleteOwnPostController } from '../controllers/post.controller';
 import { getReportedPostsController } from "../controllers/reportedPosts.controller";
+import { checkUserSuspension } from '../../middleware/suspension.middleware';
 import { createPostController, getPostsFeedController } from '../controllers/postCrud.controller';
 
 const router = Router();
 
 // GET
 // Get user posts route (protected by JWT)
-router.get('/user/posts/mine', authenticateJWT, getUserPostsController as RequestHandler);
+router.get('/user/posts/mine', authenticateJWT, checkUserSuspension, getUserPostsController as RequestHandler);
 
 // Get posts for a specific user by UUID route (protected by JWT)
-router.get('/posts/user/:uuid', authenticateJWT, getPostsByUserIdController as RequestHandler);
+router.get('/posts/user/:uuid', authenticateJWT, checkUserSuspension, getPostsByUserIdController as RequestHandler);
 
 // Get all reported posts route (protected by JWT)
 router.get('/posts/reported', authenticateJWT, getReportedPostsController as RequestHandler);
 
 // Get posts feed route (protected by JWT)
-router.get('/posts/feed', authenticateJWT, getPostsFeedController as RequestHandler)
+router.get('/posts/feed', authenticateJWT, checkUserSuspension, getPostsFeedController as RequestHandler)
 
 // DELETE
 // Delete own post route (protected by JWT)
-router.delete('/user/posts/delete/:postId', authenticateJWT, deleteOwnPostController as unknown as RequestHandler);
+router.delete('/user/posts/delete/:postId', authenticateJWT, checkUserSuspension, deleteOwnPostController as unknown as RequestHandler);
 
 // POST
 // Create a new post (protected by JWT)
-router.post('/posts/newPost', authenticateJWT, createPostController as RequestHandler);;
+router.post('/posts/newPost', authenticateJWT, checkUserSuspension, createPostController as RequestHandler);;
 
 // Get post by ID route (protected by JWT)
-router.get('/user/posts/:postId', authenticateJWT, getPostByIdController as RequestHandler);
+router.get('/user/posts/:postId', authenticateJWT, checkUserSuspension, getPostByIdController as RequestHandler);
 
 export default router;

--- a/src/features/users/repositories/userSuspension.repository.ts
+++ b/src/features/users/repositories/userSuspension.repository.ts
@@ -1,0 +1,14 @@
+import client from '../../../config/database';
+
+export const isUserSuspended = async (userId: string): Promise<boolean> => {
+    const query = `
+    SELECT 1
+    FROM user_suspensions
+    WHERE user_id = $1
+      AND start_date <= NOW()
+      AND end_date > NOW()
+    LIMIT 1;
+  `;
+    const result = await client.query(query, [userId]);
+    return result.rows.length > 0;
+};

--- a/test-api/middleware/suspension.middleware.test.ts
+++ b/test-api/middleware/suspension.middleware.test.ts
@@ -1,0 +1,68 @@
+jest.mock('../../src/features/users/repositories/userSuspension.repository');
+
+import { Request, Response, NextFunction } from 'express';
+import { checkUserSuspension } from '../../src/features/middleware/suspension.middleware';
+import { isUserSuspended } from '../../src/features/users/repositories/userSuspension.repository';
+import { ForbiddenError } from '../../src/utils/errors/api-error';
+
+const mockedIsUserSuspended = isUserSuspended as jest.Mock;
+
+describe('Suspension Middleware', () => {
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+    let nextFunction: NextFunction;
+
+    beforeEach(() => {
+        mockRequest = {
+            user: { uuid: 'user-uuid' },
+        } as Request;
+        mockResponse = {} as Response;
+        nextFunction = jest.fn();
+        jest.clearAllMocks();
+    });
+
+    describe('checkUserSuspension', () => {
+        it('should call next() when user is not suspended', async () => {
+            mockedIsUserSuspended.mockResolvedValueOnce(false);
+
+            await checkUserSuspension(
+                mockRequest as Request,
+                mockResponse as Response,
+                nextFunction
+            );
+
+            expect(mockedIsUserSuspended).toHaveBeenCalledWith('user-uuid');
+            expect(nextFunction).toHaveBeenCalledWith();
+        });
+
+        it('should pass ForbiddenError when user is suspended', async () => {
+            mockedIsUserSuspended.mockResolvedValueOnce(true);
+
+            await checkUserSuspension(
+                mockRequest as Request,
+                mockResponse as Response,
+                nextFunction
+            );
+
+            expect(mockedIsUserSuspended).toHaveBeenCalledWith('user-uuid');
+            expect(nextFunction).toHaveBeenCalledWith(expect.any(ForbiddenError));
+
+            // Optional: verify the error message
+            const errorArg = (nextFunction as jest.Mock).mock.calls[0][0] as ForbiddenError;
+            expect(errorArg.message).toBe('User is suspended');
+        });
+
+        it('should forward repository errors to next()', async () => {
+            const repoError = new Error('DB failure');
+            mockedIsUserSuspended.mockRejectedValueOnce(repoError);
+
+            await checkUserSuspension(
+                mockRequest as Request,
+                mockResponse as Response,
+                nextFunction
+            );
+
+            expect(nextFunction).toHaveBeenCalledWith(repoError);
+        });
+    });
+});

--- a/test-api/repositories/userSuspension.repository.test.ts
+++ b/test-api/repositories/userSuspension.repository.test.ts
@@ -1,0 +1,34 @@
+import { isUserSuspended } from '../../src/features/users/repositories/userSuspension.repository';
+import client from '../../src/config/database';
+import { QueryResult } from 'pg';
+
+jest.mock('../../src/config/database', () => ({
+    query: jest.fn(),
+}));
+
+const mockClient = client as unknown as { query: jest.Mock };
+
+describe('isUserSuspended', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return true when an active suspension exists', async () => {
+        const mockResult = { rows: [{ id: '1' }] } as QueryResult;
+        mockClient.query.mockResolvedValueOnce(mockResult);
+
+        const result = await isUserSuspended('user-uuid');
+
+        expect(mockClient.query).toHaveBeenCalledWith(expect.any(String), ['user-uuid']);
+        expect(result).toBe(true);
+    });
+
+    it('should return false when no active suspension exists', async () => {
+        mockClient.query.mockResolvedValueOnce({ rows: [] } as QueryResult);
+
+        const result = await isUserSuspended('user-uuid');
+
+        expect(mockClient.query).toHaveBeenCalledWith(expect.any(String), ['user-uuid']);
+        expect(result).toBe(false);
+    });
+});

--- a/test-api/routes/comment.routes.test.ts
+++ b/test-api/routes/comment.routes.test.ts
@@ -1,56 +1,76 @@
-import request from 'supertest';
-import express from 'express';
+// test-api/routes/comment.routes.test.ts
 
-// Mock _before_ you import the router so that authenticateJWT
-// and the controller are already jest-tracked when the routes load.
+import request from 'supertest';
+import express, { ErrorRequestHandler } from 'express';
+
+// Mocks must come *before* the imports of your router and middleware
 jest.mock('../../src/features/middleware/authenticate.middleware');
+jest.mock('../../src/features/middleware/suspension.middleware');
 jest.mock('../../src/features/posts/controllers/commentCrud.controller');
 
 import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
+import { checkUserSuspension } from '../../src/features/middleware/suspension.middleware';
 import { getPostCommentsController } from '../../src/features/posts/controllers/commentCrud.controller';
 import commentRoutes from '../../src/features/posts/routes/comment.routes';
+import { errorHandler } from '../../src/utils/errors/error-handler.middleware';
+import { ForbiddenError } from '../../src/utils/errors/api-error';
 
 const app = express();
 app.use(express.json());
 app.use(commentRoutes);
+// ← mount your error handler so next(err) gets turned into a JSON response
+app.use(errorHandler as ErrorRequestHandler);
 
 describe('GET /posts/:postId/comments', () => {
     const mockedAuthenticateJWT = jest.mocked(authenticateJWT);
-    const mockedController     = jest.mocked(getPostCommentsController);
+    const mockedSuspension       = jest.mocked(checkUserSuspension);
+    const mockedController       = jest.mocked(getPostCommentsController);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should return 200 when authenticated', async () => {
-        // simulate successful JWT auth
+    it('200 → when authenticated & not suspended', async () => {
         mockedAuthenticateJWT.mockImplementation((req, res, next) => next());
-
-        // simulate controller sending a 200
+        mockedSuspension.mockImplementation((req, res, next) => next());
         mockedController.mockImplementation((req, res) => {
             res.status(200).json({ message: 'ok' });
         });
 
         const res = await request(app)
-            .get('/posts/1/comments')              // <–– note leading slash
-            .set('Authorization', 'Bearer token')
+            .get('/posts/1/comments')
+            .set('Authorization', 'Bearer valid-token')
             .query({ startTime: new Date().toISOString(), index: 0 });
 
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ message: 'ok' });
     });
 
-    it('should return 401 when not authenticated', async () => {
-        // simulate auth failure
+    it('401 → when not authenticated', async () => {
         mockedAuthenticateJWT.mockImplementation((req, res) => {
             res.status(401).json({ message: 'Unauthorized' });
         });
 
         const res = await request(app)
-            .get('/posts/49f40bce-9a9b-448e-b4ff-59193d4e62lk/comments')  // <–– leading slash
+            .get('/posts/abcdef/comments')
             .query({ startTime: new Date().toISOString(), index: 0 });
 
         expect(res.status).toBe(401);
         expect(res.body).toEqual({ message: 'Unauthorized' });
+    });
+
+    it('403 → when user is suspended', async () => {
+        mockedAuthenticateJWT.mockImplementation((req, res, next) => next());
+        mockedSuspension.mockImplementation((req, res, next) =>
+            next(new ForbiddenError('User suspended'))
+        );
+
+        const res = await request(app)
+            .get('/posts/1/comments')
+            .set('Authorization', 'Bearer valid-token')
+            .query({ startTime: new Date().toISOString(), index: 0 });
+
+        expect(res.status).toBe(403);
+        expect(res.body).toEqual({ message: 'User suspended' });
     });
 });

--- a/test-api/routes/delete.post.routes.test.ts
+++ b/test-api/routes/delete.post.routes.test.ts
@@ -1,48 +1,90 @@
-import request from "supertest";
-import express from "express";
-import { deleteOwnPostController } from "../../src/features/posts/controllers/post.controller";
-import postRoutes from "../../src/features/posts/routes/post.routes";
-import { authenticateJWT } from "../../src/features/middleware/authenticate.middleware";
+// test-api/routes/delete.post.routes.test.ts
 
-jest.mock("../../src/features/posts/controllers/post.controller");
-jest.mock("../../src/features/middleware/authenticate.middleware");
+import request from 'supertest';
+import express, { ErrorRequestHandler } from 'express';
+
+// Hoist these mocks BEFORE importing anything that uses them
+jest.mock('../../src/features/middleware/authenticate.middleware');
+jest.mock('../../src/features/middleware/suspension.middleware');
+jest.mock('../../src/features/posts/controllers/post.controller');
+
+import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
+import { checkUserSuspension } from '../../src/features/middleware/suspension.middleware';
+import { deleteOwnPostController } from '../../src/features/posts/controllers/post.controller';
+import postRoutes from '../../src/features/posts/routes/post.routes';
+import { errorHandler } from '../../src/utils/errors/error-handler.middleware';
 
 const app = express();
 app.use(express.json());
-app.use("/api", postRoutes);
+app.use('/api', postRoutes);
+// mount your global error handler
+app.use(errorHandler as ErrorRequestHandler);
 
-describe("DELETE /api/user/posts/delete/:postId", () => {
+describe('DELETE /api/user/posts/delete/:postId', () => {
+  const mockedAuth       = jest.mocked(authenticateJWT);
+  const mockedSuspend    = jest.mocked(checkUserSuspension);
+  const mockedDeleteCtrl = jest.mocked(deleteOwnPostController);
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should call the controller for an authenticated user", async () => {
-    (authenticateJWT as jest.Mock).mockImplementation((req, res, next) => {
-      req.user = { uuid: "user-123" };
+  it('200 → calls controller for authenticated & not suspended user', async () => {
+    // stub auth + suspension
+    mockedAuth.mockImplementation((req, res, next) => {
+      req.user = { uuid: 'user-123' };
       next();
     });
+    mockedSuspend.mockImplementation((req, res, next) => next());
 
-    (deleteOwnPostController as jest.Mock).mockImplementation((req, res) => {
-      res.status(200).json({ status: "success", message: "Post successfully deleted." });
+    // stub controller
+    mockedDeleteCtrl.mockImplementation((req, res) => {
+      res.status(200).json({
+        status: 'success',
+        message: 'Post successfully deleted.',
+      });
     });
 
-    const response = await request(app)
-      .delete("/api/user/posts/delete/post-123"); // ← ID en la URL
+    const res = await request(app)
+        .delete('/api/user/posts/delete/post-123')
+        .set('Authorization', 'Bearer valid-token');
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({ status: "success", message: "Post successfully deleted." });
-    expect(deleteOwnPostController).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      status: 'success',
+      message: 'Post successfully deleted.',
+    });
+
+    // verify each layer ran
+    expect(mockedAuth).toHaveBeenCalled();
+    expect(mockedSuspend).toHaveBeenCalled();
+    expect(mockedDeleteCtrl).toHaveBeenCalledWith(
+        expect.objectContaining({ params: { postId: 'post-123' } }),
+        expect.anything(),
+        expect.anything()
+    );
   });
 
-  it("should block unauthenticated users", async () => {
-    (authenticateJWT as jest.Mock).mockImplementation((req, res) => {
-      res.status(401).json({ status: "error", message: "Unauthorized" });
+  it('401 → blocks unauthenticated users', async () => {
+    // auth fails; suspension & controller never called
+    mockedAuth.mockImplementation((req, res) => {
+      res.status(401).json({
+        status: 'error',
+        message: 'Unauthorized',
+      });
     });
 
-    const response = await request(app)
-      .delete("/api/user/posts/delete/post-123"); // ← ID en la URL
+    const res = await request(app)
+        .delete('/api/user/posts/delete/post-123');
 
-    expect(response.status).toBe(401);
-    expect(response.body).toEqual({ status: "error", message: "Unauthorized" });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      status: 'error',
+      message: 'Unauthorized',
+    });
+
+    expect(mockedAuth).toHaveBeenCalled();
+    expect(mockedSuspend).not.toHaveBeenCalled();
+    expect(mockedDeleteCtrl).not.toHaveBeenCalled();
   });
 });

--- a/test-api/routes/getPostById.routes.test.ts
+++ b/test-api/routes/getPostById.routes.test.ts
@@ -1,53 +1,55 @@
+// Hoist all mocks before loading the router
+jest.mock('../../src/features/middleware/authenticate.middleware');
+jest.mock('../../src/features/middleware/suspension.middleware');
+jest.mock('../../src/features/posts/controllers/getPosts.controller');
+
 import request from 'supertest';
-import express from 'express';
+import express, { ErrorRequestHandler } from 'express';
+
 import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
+import { checkUserSuspension } from '../../src/features/middleware/suspension.middleware';
 import { getPostByIdController } from '../../src/features/posts/controllers/getPosts.controller';
 import postsRoutes from '../../src/features/posts/routes/post.routes';
+import { errorHandler } from '../../src/utils/errors/error-handler.middleware';
+import { ForbiddenError } from '../../src/utils/errors/api-error';
 
-// Create testing app
 const app = express();
 app.use(express.json());
 app.use(postsRoutes);
-
-jest.mock('../../src/features/middleware/authenticate.middleware');
-jest.mock('../../src/features/posts/controllers/getPosts.controller');
+// mount your global error handler
+app.use(errorHandler as ErrorRequestHandler);
 
 describe('GET /user/posts/:postId', () => {
-  const mockedAuthenticateJWT = jest.mocked(authenticateJWT);
-  const mockedGetPostByIdController = jest.mocked(getPostByIdController);
+  const mockedAuth       = jest.mocked(authenticateJWT);
+  const mockedSuspend    = jest.mocked(checkUserSuspension);
+  const mockedController = jest.mocked(getPostByIdController);
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return 200 and post details when authenticated with valid role', async () => {
-    // Mock authentication with user role
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('200 → returns post details when authenticated as admin', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    // Mock successful response
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(200).json({
         message: 'Post fetched successfully',
         post: {
           id: '123',
           content: 'Test post',
           comments: [],
-          comments_metadata: {
-            totalItems: 0,
-            totalPages: 0,
-            currentPage: 1
-          }
-        }
+          comments_metadata: { totalItems: 0, totalPages: 0, currentPage: 1 },
+        },
       });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: 1, commentLimit: 5 })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: 1, commentLimit: 5 });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -56,174 +58,173 @@ describe('GET /user/posts/:postId', () => {
         id: '123',
         content: 'Test post',
         comments: [],
-        comments_metadata: {
-          totalItems: 0,
-          totalPages: 0,
-          currentPage: 1
-        }
-      }
+        comments_metadata: { totalItems: 0, totalPages: 0, currentPage: 1 },
+      },
     });
+    expect(mockedAuth).toHaveBeenCalled();
+    expect(mockedSuspend).toHaveBeenCalled();
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should return 401 when not authenticated', async () => {
-    mockedAuthenticateJWT.mockImplementation((req, res) => {
+  it('401 → when not authenticated', async () => {
+    mockedAuth.mockImplementation((req, res) => {
       res.status(401).json({ message: 'Unauthorized' });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: 1, commentLimit: 5 });
+        .get('/user/posts/123')
+        .query({ commentPage: 1, commentLimit: 5 });
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({ message: 'Unauthorized' });
+    expect(mockedSuspend).not.toHaveBeenCalled();
+    expect(mockedController).not.toHaveBeenCalled();
   });
 
-  it('should return 401 when user has invalid role', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'user' };
+  it('401 → when user has invalid role', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'user' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(401).json({ message: 'User not authenticated' });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: 1, commentLimit: 5 })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: 1, commentLimit: 5 });
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({ message: 'User not authenticated' });
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should return 400 when query parameters are invalid', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('400 → when commentPage is less than 1', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(400).json({
         message: 'Validation error',
-        errors: ['The comment page must be at least 1']
+        errors: ['The comment page must be at least 1'],
       });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: 0, commentLimit: 5 })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: 0, commentLimit: 5 });
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       message: 'Validation error',
-      errors: ['The comment page must be at least 1']
+      errors: ['The comment page must be at least 1'],
     });
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should return 400 when commentLimit exceeds maximum', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('400 → when commentLimit exceeds maximum', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(400).json({
         message: 'Validation error',
-        errors: ['The comment limit must not exceed 20']
+        errors: ['The comment limit must not exceed 20'],
       });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: 1, commentLimit: 25 })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: 1, commentLimit: 25 });
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       message: 'Validation error',
-      errors: ['The comment limit must not exceed 20']
+      errors: ['The comment limit must not exceed 20'],
     });
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should use default values when no query parameters are provided', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('200 → uses default pagination when no query params are provided', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(200).json({
         message: 'Post fetched successfully',
         post: {
           id: '123',
           content: 'Test post',
           comments: [],
-          comments_metadata: {
-            totalItems: 0,
-            totalPages: 0,
-            currentPage: 1  // default page
-          }
-        }
+          comments_metadata: { totalItems: 0, totalPages: 0, currentPage: 1 },
+        },
       });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token');
 
     expect(response.status).toBe(200);
     expect(response.body.post.comments_metadata.currentPage).toBe(1);
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should handle string values for numeric parameters', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('200 → handles string values for numeric params', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(200).json({
         message: 'Post fetched successfully',
         post: {
           id: '123',
           content: 'Test post',
           comments: [],
-          comments_metadata: {
-            totalItems: 0,
-            totalPages: 0,
-            currentPage: 2
-          }
-        }
+          comments_metadata: { totalItems: 0, totalPages: 0, currentPage: 2 },
+        },
       });
     });
 
     const response = await request(app)
-      .get('/user/posts/123')
-      .query({ commentPage: '2', commentLimit: '10' })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/123')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: '2', commentLimit: '10' });
 
     expect(response.status).toBe(200);
     expect(response.body.post.comments_metadata.currentPage).toBe(2);
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should return 404 when post is not found', async () => {
-    mockedAuthenticateJWT.mockImplementation((req: any, res, next) => {
-      req.user = { role: 'admin' };
+  it('404 → when post is not found', async () => {
+    mockedAuth.mockImplementation((req, _res, next) => {
+      (req as any).user = { role: 'admin' };
       next();
     });
-
-    mockedGetPostByIdController.mockImplementation(async (req, res, next) => {
+    mockedSuspend.mockImplementation((req, _res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(404).json({ message: 'Post not found' });
     });
 
     const response = await request(app)
-      .get('/user/posts/nonexistent')
-      .query({ commentPage: 1, commentLimit: 5 })
-      .set('Authorization', 'Bearer valid-token');
+        .get('/user/posts/nonexistent')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ commentPage: 1, commentLimit: 5 });
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({ message: 'Post not found' });
+    expect(mockedController).toHaveBeenCalled();
   });
 });

--- a/test-api/routes/getPosts.routes.test.ts
+++ b/test-api/routes/getPosts.routes.test.ts
@@ -1,27 +1,38 @@
+// test-api/routes/getUserPosts.routes.test.ts
+
+jest.mock('../../src/features/middleware/authenticate.middleware');
+jest.mock('../../src/features/middleware/suspension.middleware');
+jest.mock('../../src/features/posts/controllers/getPosts.controller');
+
 import request from 'supertest';
-import express from 'express';import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
+import express, { ErrorRequestHandler } from 'express';
+
+import { authenticateJWT } from '../../src/features/middleware/authenticate.middleware';
+import { checkUserSuspension } from '../../src/features/middleware/suspension.middleware';
 import { getUserPostsController } from '../../src/features/posts/controllers/getPosts.controller';
 import postsRoutes from '../../src/features/posts/routes/post.routes';
+import { errorHandler } from '../../src/utils/errors/error-handler.middleware';
+import { ForbiddenError } from '../../src/utils/errors/api-error';
 
-// Creamos una app de testing
 const app = express();
 app.use(express.json());
 app.use(postsRoutes);
-
-jest.mock('../../src/features/middleware/authenticate.middleware');
-jest.mock('../../src/features/posts/controllers/getPosts.controller');
+// mount error handler to catch next(err)
+app.use(errorHandler as ErrorRequestHandler);
 
 describe('GET /api/user/posts/mine', () => {
-  const mockedAuthenticateJWT = jest.mocked(authenticateJWT);
-  const mockedGetUserPostsController = jest.mocked(getUserPostsController);
+  const mockedAuth      = jest.mocked(authenticateJWT);
+  const mockedSuspend   = jest.mocked(checkUserSuspension);
+  const mockedController = jest.mocked(getUserPostsController);
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return 200 and posts when authenticated', async () => {
-    mockedAuthenticateJWT.mockImplementation((req, res, next) => next());
-    mockedGetUserPostsController.mockImplementation((req, res) => {
+  it('200 → returns posts when authenticated & not suspended', async () => {
+    mockedAuth.mockImplementation((req, res, next) => next());
+    mockedSuspend.mockImplementation((req, res, next) => next());
+    mockedController.mockImplementation((req, res) => {
       res.status(200).json({
         message: 'Posts fetched successfully',
         posts: [],
@@ -33,12 +44,12 @@ describe('GET /api/user/posts/mine', () => {
       });
     });
 
-    const response = await request(app)
-      .get('/user/posts/mine')
-      .set('Authorization', 'Bearer valid-token');
+    const res = await request(app)
+        .get('/user/posts/mine')
+        .set('Authorization', 'Bearer valid-token');
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
       message: 'Posts fetched successfully',
       posts: [],
       metadata: {
@@ -47,16 +58,37 @@ describe('GET /api/user/posts/mine', () => {
         currentPage: 1,
       },
     });
+
+    expect(mockedAuth).toHaveBeenCalled();
+    expect(mockedSuspend).toHaveBeenCalled();
+    expect(mockedController).toHaveBeenCalled();
   });
 
-  it('should return 401 when not authenticated', async () => {
-    mockedAuthenticateJWT.mockImplementation((req, res) => {
+  it('401 → when not authenticated', async () => {
+    mockedAuth.mockImplementation((req, res) => {
       res.status(401).json({ message: 'Unauthorized' });
     });
 
-    const response = await request(app).get('/user/posts/mine');
+    const res = await request(app).get('/user/posts/mine');
 
-    expect(response.status).toBe(401);
-    expect(response.body).toEqual({ message: 'Unauthorized' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Unauthorized' });
+    expect(mockedSuspend).not.toHaveBeenCalled();
+    expect(mockedController).not.toHaveBeenCalled();
+  });
+
+  it('403 → when user is suspended', async () => {
+    mockedAuth.mockImplementation((req, res, next) => next());
+    mockedSuspend.mockImplementation((req, res, next) =>
+        next(new ForbiddenError('User suspended'))
+    );
+
+    const res = await request(app)
+        .get('/user/posts/mine')
+        .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'User suspended' });
+    expect(mockedController).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Restrict access on suspended accounts | Post Microservices 

Implemented a checkUserSuspension middleware that looks up the user’s account status and throws a ForbiddenError when the account is suspended

Added an isUserSuspended repository function to query user_suspensions for active suspensions

Applied the new middleware to comment, post, reportedPost, and report route handlers so suspended users are blocked from these endpoints

Added Jest unit tests covering the middleware logic and the repository query

---

**This feature might be implemented on all Microservices, therefore at this point _Posts_ and _User_ Microservices are priorized,** 