### PR TITLE
feat: include comments count in posts retrieval query

### DIFF
--- a/src/features/posts/repositories/getPosts.repository.ts
+++ b/src/features/posts/repositories/getPosts.repository.ts
@@ -36,9 +36,21 @@ export const getVisiblePostsByUserIdPaginated = async (user_id: string, offset: 
  */
 export const getVisiblePostsByUserIdAndTime = async (user_id: string, timestamp: string, limit: number) => {
   const postQuery = `
-    SELECT id, user_id, content, file_url, media_type, created_at FROM posts 
-    WHERE user_id = $1 AND status = 1 AND is_active = true AND created_at < $2
-    ORDER BY created_at DESC 
+    SELECT 
+      p.id, 
+      p.user_id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true AND p.created_at < $2
+    ORDER BY p.created_at DESC 
     LIMIT $3
   `;
 

--- a/test-api/repositories/user.posts.repository.test.ts
+++ b/test-api/repositories/user.posts.repository.test.ts
@@ -124,7 +124,24 @@ describe('User Posts Repository', () => {
 
       expect(result).toEqual(mockPosts);
       expect(mockClient.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, user_id, content, file_url, media_type, created_at FROM posts'),
+        expect.stringContaining( `
+    SELECT 
+      p.id, 
+      p.user_id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true AND p.created_at < $2
+    ORDER BY p.created_at DESC 
+    LIMIT $3
+  `),
         ['user-uuid', timestamp, 10]
       );
     });
@@ -144,7 +161,24 @@ describe('User Posts Repository', () => {
 
       expect(result).toEqual([]);
       expect(mockClient.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, user_id, content, file_url, media_type, created_at FROM posts'),
+        expect.stringContaining( `
+    SELECT 
+      p.id, 
+      p.user_id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true AND p.created_at < $2
+    ORDER BY p.created_at DESC 
+    LIMIT $3
+  `),
         ['nonexistent-user-id', timestamp, 10]
       );
     });


### PR DESCRIPTION
This pull request updates the `getVisiblePostsByUserIdAndTime` function in the posts repository to include a count of comments for each post in the query results. Corresponding changes were made to the unit tests to validate the updated query structure.