### PR TITLE
Fix/return comments count in get own posts endpoint

### DIFF
--- a/src/features/posts/repositories/getPosts.repository.ts
+++ b/src/features/posts/repositories/getPosts.repository.ts
@@ -11,11 +11,21 @@ import { QueryResult } from 'pg'; // Importing QueryResult for type safety
  * @throws Any error thrown by the database client.
  */
 export const getVisiblePostsByUserIdPaginated = async (user_id: string, offset: number, limit: number) => {
-  // Fetching user UUID by email
   const postQuery = `
-    SELECT id, content, file_url, media_type, created_at FROM posts 
-    WHERE user_id = $1 AND status = 1 AND is_active = true
-    ORDER BY created_at DESC 
+    SELECT 
+      p.id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true
+    ORDER BY p.created_at DESC 
     LIMIT $2 OFFSET $3
   `;
 

--- a/test-api/repositories/user.posts.repository.test.ts
+++ b/test-api/repositories/user.posts.repository.test.ts
@@ -36,7 +36,23 @@ describe('User Posts Repository', () => {
 
       expect(result).toEqual(mockPosts);
       expect(mockClient.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, content, file_url, media_type, created_at FROM posts'),
+        expect.stringContaining(`
+    SELECT 
+      p.id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true
+    ORDER BY p.created_at DESC 
+    LIMIT $2 OFFSET $3
+  `),
         ['user-uuid', 10, 0]
       );
     });
@@ -54,7 +70,23 @@ describe('User Posts Repository', () => {
 
       expect(result).toEqual([]);
       expect(mockClient.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, content, file_url, media_type, created_at FROM posts'),
+        expect.stringContaining(`
+    SELECT 
+      p.id, 
+      p.content, 
+      p.file_url, 
+      p.media_type, 
+      p.created_at,
+      (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id
+      ) AS comments_count
+    FROM posts p
+    WHERE p.user_id = $1 AND p.status = 1 AND p.is_active = true
+    ORDER BY p.created_at DESC 
+    LIMIT $2 OFFSET $3
+  `),
         ['nonexistent-user-id', 10, 0]
       );
     });


### PR DESCRIPTION
This pull request updates the `getVisiblePostsByUserIdPaginated` and `getVisiblePostsByUserIdAndTime` repository functions to include a count of comments for each post, and modifies related tests to reflect these changes. The most important changes include SQL query updates for both functions and adjustments to the corresponding unit tests.